### PR TITLE
Wiring up a "backend" for the url history

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,12 +2,14 @@ import Container from "@mui/material/Container";
 
 import Layout from "./Layout";
 import { UrlShortener } from "./features/url-shortener";
+import { UrlHistory } from "./features/url-history";
 
 function App() {
   return (
     <Layout>
       <Container maxWidth="sm">
         <UrlShortener />
+        <UrlHistory />
       </Container>
     </Layout>
   );

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -17,6 +17,10 @@ const Background = styled.main`
 
 const Offset = styled("div")(({ theme }) => theme.mixins.toolbar);
 
+/**
+ *
+ * @todo I wonder if ThemeProvider shoudld live in index.js...
+ */
 const Layout = ({ children }) => (
   <ThemeProvider theme={theme}>
     <CssBaseline />

--- a/src/app/ajax.js
+++ b/src/app/ajax.js
@@ -1,14 +1,9 @@
 import { API } from "../constants";
 
-/**
- * @todo check that this works
- * specifically, get parameters
- */
 export async function getData(url = "") {
   const response = await fetch(url, {
     cache: "no-cache",
     headers: {
-      // "Content-Type": "application/json",
       "GB-Access-Token": API.KEY,
     },
     referrerPolicy: "no-referrer",

--- a/src/app/ajax.js
+++ b/src/app/ajax.js
@@ -1,16 +1,17 @@
 import { API } from "../constants";
 
-/** @todo check that this works */
-export async function getData(url = "", data = {}) {
+/**
+ * @todo check that this works
+ * specifically, get parameters
+ */
+export async function getData(url = "") {
   const response = await fetch(url, {
-    method: "GET",
     cache: "no-cache",
     headers: {
-      "Content-Type": "application/json",
+      // "Content-Type": "application/json",
       "GB-Access-Token": API.KEY,
     },
     referrerPolicy: "no-referrer",
-    body: JSON.stringify(data),
   });
   return response.json();
 }

--- a/src/app/ajax.js
+++ b/src/app/ajax.js
@@ -1,5 +1,20 @@
 import { API } from "../constants";
 
+/** @todo check that this works */
+export async function getData(url = "", data = {}) {
+  const response = await fetch(url, {
+    method: "GET",
+    cache: "no-cache",
+    headers: {
+      "Content-Type": "application/json",
+      "GB-Access-Token": API.KEY,
+    },
+    referrerPolicy: "no-referrer",
+    body: JSON.stringify(data),
+  });
+  return response.json();
+}
+
 export async function postData(url = "", data = {}) {
   const response = await fetch(url, {
     method: "POST",

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,8 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { shortenerReducer } from "../features/url-shortener";
+import { historyReducer } from "../features/url-history";
 
 export const store = configureStore({
   reducer: {
     shortener: shortenerReducer,
+    history: historyReducer,
   },
 });

--- a/src/features/url-history/UrlHistory.jsx
+++ b/src/features/url-history/UrlHistory.jsx
@@ -1,17 +1,20 @@
 import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 
-import { getHistory } from "./historyAPI";
+import { getHistoryAsync } from "./historySlice";
 
 const UrlHistory = () => {
+  const dispatch = useDispatch();
+  const { urls } = useSelector((state) => state.history);
+
   useEffect(() => {
-    async function fetchData() {
-      const result = await getHistory();
-      console.log(result);
-    }
-    fetchData();
+    dispatch(getHistoryAsync());
   }, []);
+
+  console.log("urls", urls);
+
   return (
     <Card sx={{ minWidth: 275 }}>
       <CardContent>Url history placeholder</CardContent>

--- a/src/features/url-history/UrlHistory.jsx
+++ b/src/features/url-history/UrlHistory.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+
+const UrlHistory = () => {
+  <Card sx={{ minWidth: 275 }}>
+    <CardContent>Url history placeholder</CardContent>
+  </Card>;
+};
+
+export default UrlHistory;

--- a/src/features/url-history/UrlHistory.jsx
+++ b/src/features/url-history/UrlHistory.jsx
@@ -1,11 +1,22 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 
+import { getHistory } from "./historyAPI";
+
 const UrlHistory = () => {
-  <Card sx={{ minWidth: 275 }}>
-    <CardContent>Url history placeholder</CardContent>
-  </Card>;
+  useEffect(() => {
+    async function fetchData() {
+      const result = await getHistory();
+      console.log(result);
+    }
+    fetchData();
+  }, []);
+  return (
+    <Card sx={{ minWidth: 275 }}>
+      <CardContent>Url history placeholder</CardContent>
+    </Card>
+  );
 };
 
 export default UrlHistory;

--- a/src/features/url-history/historyAPI.js
+++ b/src/features/url-history/historyAPI.js
@@ -1,0 +1,6 @@
+import { getData } from "../../app/ajax";
+import { API } from "../../constants";
+
+export function shortenUrl() {
+  return getData(`${API.BASE}/links`);
+}

--- a/src/features/url-history/historyAPI.js
+++ b/src/features/url-history/historyAPI.js
@@ -1,6 +1,6 @@
 import { getData } from "../../app/ajax";
 import { API } from "../../constants";
 
-export function shortenUrl() {
+export function getHistory() {
   return getData(`${API.BASE}/links`);
 }

--- a/src/features/url-history/historySlice.js
+++ b/src/features/url-history/historySlice.js
@@ -12,7 +12,7 @@ const initialState = {
   loading: false,
 };
 
-const getHistoryAsync = createAsyncThunk("history/get", async () => {
+export const getHistoryAsync = createAsyncThunk("history/get", async () => {
   const response = await getHistory();
   return response;
 });

--- a/src/features/url-history/historySlice.js
+++ b/src/features/url-history/historySlice.js
@@ -1,0 +1,37 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { getHistory } from "./historyAPI";
+
+const initialState = {
+  urls: [
+    // {
+    //   short_url: "http://bely.me/mZ9G",
+    //   slug: "mZ9G",
+    //   url: "https://gb.com/shorty",
+    // },
+  ],
+  loading: false,
+};
+
+const getHistoryAsync = createAsyncThunk("history/get", async () => {
+  const response = await getHistory();
+  return response;
+});
+
+export const historySlice = createSlice({
+  name: "history",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(getHistoryAsync.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(getHistoryAsync.fulfilled, (state, action) => {
+        state.loading = false;
+        state.urls = action.payload;
+      });
+    /** @todo add error case */
+  },
+});
+
+export default historySlice.reducer;

--- a/src/features/url-history/index.js
+++ b/src/features/url-history/index.js
@@ -1,1 +1,2 @@
 export { default as UrlHistory } from "./UrlHistory";
+export { default as historyReducer } from "./historySlice";

--- a/src/features/url-history/index.js
+++ b/src/features/url-history/index.js
@@ -1,0 +1,1 @@
+export { default as UrlHistory } from "./UrlHistory";


### PR DESCRIPTION
Developing a connection to the `/links` API, to fetch shortened url history.

Adding a `GET` method to `ajax.js`.

Setting up a reducer to house the url history.

Scaffolding a basic UI card that will in the future display the url history, and support the expiration interaction.